### PR TITLE
test ideas

### DIFF
--- a/c++11/src/lightstep_span.cpp
+++ b/c++11/src/lightstep_span.cpp
@@ -30,7 +30,7 @@ static std::tuple<SystemTime, SteadyTime> ComputeStartTimestamps(
         start_system_timestamp,
         opentracing::convert_time_point<SteadyClock>(start_system_timestamp)};
   }
-  return {start_system_timestamp, start_steady_timestamp};
+  return std::tuple<SystemTime, SteadyTime>{start_system_timestamp, start_steady_timestamp};
 }
 
 //------------------------------------------------------------------------------

--- a/c++11/src/lightstep_tracer_impl.cpp
+++ b/c++11/src/lightstep_tracer_impl.cpp
@@ -39,7 +39,7 @@ opentracing::expected<std::unique_ptr<opentracing::SpanContext>> ExtractImpl(
   if (!*result) {
     span_context.reset();
   }
-  return span_context;
+  return std::move(span_context);
 }
 
 //------------------------------------------------------------------------------

--- a/c++11/src/tracer.cpp
+++ b/c++11/src/tracer.cpp
@@ -58,7 +58,7 @@ LightStepTracer::MakeSpanContext(
     std::unordered_map<std::string, std::string>&& baggage) const noexcept try {
   std::unique_ptr<opentracing::SpanContext> result{
       new LightStepSpanContext{trace_id, span_id, std::move(baggage)}};
-  return result;
+  return std::move(result);
 } catch (const std::bad_alloc&) {
   return opentracing::make_unexpected(
       std::make_error_code(std::errc::not_enough_memory));

--- a/c++11/test/recorder_test.cpp
+++ b/c++11/test/recorder_test.cpp
@@ -10,6 +10,16 @@
 using namespace lightstep;
 using namespace opentracing;
 
+static thread_local std::mt19937 rng{std::random_device()()};
+
+static std::chrono::steady_clock::duration delta = std::chrono::milliseconds(1);
+
+void printTime(const char * what, const std::chrono::steady_clock::time_point& t) {
+  auto tse =  t.time_since_epoch();
+  auto dur = std::chrono::duration_cast<std::chrono::milliseconds>( tse ).count();
+  std::cout << what << "=" << dur << std::endl;
+};
+
 TEST_CASE("rpc_recorder") {
   spdlog::logger logger{"lightstep", spdlog::sinks::stderr_sink_mt::instance()};
   LightStepTracerOptions options;
@@ -51,5 +61,183 @@ TEST_CASE("rpc_recorder") {
     span_generator.Run(std::chrono::milliseconds(250));
     tracer->Close();
     CHECK(in_memory_transporter->spans().size() == 0);
+  }
+}
+
+struct TestInterface : public BufferedRecorder::TestInterface {
+	BufferedRecorder::time_point t_now;
+	
+	virtual BufferedRecorder::time_point now() { return t_now; }
+	
+	std::function<bool()> wait_for_cb;
+
+    virtual bool wait_for(
+					 std::condition_variable& write_cond_,
+					 std::unique_lock<std::mutex>& lock,
+					 const BufferedRecorder::duration& rel_time,
+					 BufferedRecorder::Predicate pred) {
+	  return true;
+    }
+
+	std::function<void(const BufferedRecorder::time_point&,
+                       std::unique_lock<std::mutex>& lock)> wait_until_cb;
+
+    virtual void wait_until(
+		           std::condition_variable& write_cond_,
+	               std::unique_lock<std::mutex>& lock,
+                   const BufferedRecorder::time_point& timeout_time,
+                   BufferedRecorder::Predicate pred ) {
+	  wait_until_cb(timeout_time, lock);
+    }
+	
+	void advanceTime() {
+		t_now += delta;
+	}
+};
+
+TEST_CASE("rpc_recorder_step") {
+  spdlog::logger logger{"lightstep", spdlog::sinks::stderr_sink_mt::instance()};
+  LightStepTracerOptions options;
+  options.reporting_period = std::chrono::milliseconds(2);
+  options.max_buffered_spans = 5;
+  auto in_memory_transporter = new InMemoryTransporter();
+  auto ti = std::shared_ptr<TestInterface>(new TestInterface);
+  auto recorder = new BufferedRecorder{
+      logger, options, std::unique_ptr<Transporter>{in_memory_transporter}, ti};
+  auto tracer = std::shared_ptr<opentracing::Tracer>{
+      new LightStepTracerImpl{std::unique_ptr<Recorder>{recorder}}};
+  CHECK(tracer);
+
+  std::mutex tick, tock; tick.lock(); tock.lock();
+  BufferedRecorder::time_point timeout;
+  
+  auto defaultCallback = [&]() {
+	  ti->wait_until_cb = [&](const BufferedRecorder::time_point& till,
+	                          std::unique_lock<std::mutex>&       lock) {
+		timeout = till;
+		tick.unlock();
+		tock.lock();
+	  };
+  };
+  defaultCallback();
+
+  auto tightLoop = [&]() {
+      ti->wait_until_cb = [&](const BufferedRecorder::time_point& till,
+                              std::unique_lock<std::mutex>&       lock) {
+      	std::this_thread::yield(); // A tight loop
+      };
+  };
+  
+  auto shutdown = [&]() {
+	tick.lock(); // Another timeout
+	ti->advanceTime();
+
+	// Done
+	tightLoop();
+
+	tock.unlock();
+	
+	tracer->Close();
+  };
+  
+	  SECTION("Check that the timeout is as expected") {
+
+	for (int i = 0; i < 10; ++i) {
+		tick.lock(); // Another timeout
+
+		// This is weird...
+		auto expected = ti->t_now + (i+1) * options.reporting_period - i * delta;
+		CHECK(timeout == expected);
+		ti->advanceTime();
+		tock.unlock();
+	}
+
+	    shutdown();
+	  }
+  
+  auto sendSpan = [&]{
+	auto systemTime = convert_time_point<std::chrono::system_clock>(ti->t_now);
+	auto span = std::shared_ptr<opentracing::Span>(
+		tracer->StartSpan(std::to_string(rng()),
+	                      {opentracing::StartTimestamp(systemTime, ti->t_now)}));
+	assert(span);
+	return std::thread([&](){
+		span->Finish({opentracing::FinishTimestamp(ti->t_now + std::chrono::milliseconds(30))});
+	});
+  };
+  
+  SECTION("Single span goes through") {
+
+	tightLoop();
+
+	sendSpan().join();
+
+	    tracer->Close();
+
+	CHECK(in_memory_transporter->spans().size() == 1);
+  }
+  
+  auto step = [&]() {
+	tick.lock();
+	ti->advanceTime();
+	tock.unlock();
+  };
+  
+  std::mutex freed; freed.lock();
+  auto toManual = [&]() {
+  	ti->wait_until_cb = [&](const BufferedRecorder::time_point& till,
+  	                        std::unique_lock<std::mutex>&       lock) {
+  		// Release the lock till I tell you.
+  		tick.unlock();
+  		lock.unlock(); // Free it up for other threads
+		freed.unlock();
+  		tock.lock();
+  		lock.lock(); // Back to being locked.
+  	};
+  };
+  
+  SECTION("A span among multiple timeouts survives") {
+
+	step();
+
+	toManual();
+
+	{
+		// Send a span
+		tick.lock();
+
+		sendSpan().join();
+
+		defaultCallback(); // Restore default
+		ti->advanceTime();
+		tock.unlock();
+	}
+	
+	step(); // Many timeouts
+	step();
+	step();
+	
+	toManual();
+	
+	{
+		// Send many spans quickly
+		tick.lock();
+		freed.lock(); // Wait till buffer's lock is free
+		for (int i = 0; i < 4; ++i) {
+			sendSpan().join();
+		}
+		
+		defaultCallback(); // Restore default
+		ti->advanceTime();
+		tock.unlock();
+	}
+
+	step(); // Many timeouts
+	step();
+	step();
+
+	shutdown();
+	
+	CHECK(in_memory_transporter->spans().size() == 5);
   }
 }


### PR DESCRIPTION
It's not elegant, but there are some things that can be done. It found a bug. It's better if one designs them with testing in mind. Now this is a bit Frankenstein'ish (and has bugs)

Some other random notes:

```
opentracing-cpp/c++11/test/util_test.cpp:13:21: error: call to 'abs' is ambiguous
  auto difference = std::abs(
                    ^~~~~~~~
-> hand-made my abs

lightstep-tracer-cpp-1/c++11/src/lightstep_span.cpp:33:10: error: chosen constructor is explicit in copy-initialization
  return {start_system_timestamp, start_steady_timestamp};
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

I did: -> return std::tuple<SystemTime, SteadyTime>{start_system_timestamp, start_steady_timestamp};


lightstep-tracer-cpp-1/c++11/src/lightstep_tracer_impl.cpp:42:10: error: no viable conversion from returned value of type
      'std::unique_ptr<opentracing::SpanContext>' to function return type 'opentracing::expected<std::unique_ptr<opentracing::SpanContext> >'
  return span_context;

I did -> std::move

lightstep-tracer-cpp-1/c++11/src/lightstep_tracer_impl.cpp:42:10: error: no viable conversion from returned value of type
      'std::unique_ptr<opentracing::SpanContext>' to function return type 'opentracing::expected<std::unique_ptr<opentracing::SpanContext> >'
  return span_context;
         ^~~~~~~~~~~~


I did ->Added std::move(...)

lightstep-tracer-cpp-1/c++11/src/tracer.cpp:61:10: error: no viable conversion from returned value of type
      'std::unique_ptr<opentracing::SpanContext>' to function return type 'opentracing::expected<std::unique_ptr<opentracing::SpanContext> >'
  return result;

-> Added std::move(...)


cmake - somehow weirdly - when one does `make test`, first runs the test and then re-builds it.

There's an interesting asymmetry between StartSpan() and Finish() - regarding what they consider "default" time (for one it's system, for the other it's stable).

```